### PR TITLE
Some cmake tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,26 @@
 project(++sqlite)
 cmake_minimum_required(VERSION 2.8)
 
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+
 option(BUILD_UNIT_TESTS "Build the unit tests" ON)
 
 find_package(GTest QUIET)
 if(GTEST_FOUND)
   enable_testing()
-  include_directories("${GTEST_INCLUDE_DIRS}")
+  include_directories(${GTEST_INCLUDE_DIRS})
 else()
   message("### Google Test Framework not found, unit tests will not be built.")
   set(BUILD_UNIT_TESTS false)
 endif()
+
+find_package(sqlite REQUIRED)
+if(NOT SQLITE_FOUND)
+	message(FATAL_ERROR "SQLite required for ++sqlite")
+endif()
+
+set(XXSQLITE_LIBRARIES ++sqlite CACHE INTERNAL "")
+set(XXSQLITE_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/src CACHE INTERNAL "")
 
 add_definitions("-std=c++11")
 

--- a/cmake/Findsqlite.cmake
+++ b/cmake/Findsqlite.cmake
@@ -1,0 +1,66 @@
+# - Try to find Sqlite
+# Once done this will define
+#
+#  SQLITE_FOUND - system has Sqlite
+#  SQLITE_INCLUDE_DIR - the Sqlite include directory
+#  SQLITE_LIBRARIES - Link these to use Sqlite
+#  SQLITE_DEFINITIONS - Compiler switches required for using Sqlite
+#
+# Copyright (c) 2008, Gilles Caulier, <caulier.gilles@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. The name of the author may not be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+if ( SQLITE_INCLUDE_DIR AND SQLITE_LIBRARIES )
+   # in cache already
+   SET(Sqlite_FIND_QUIETLY TRUE)
+endif ( SQLITE_INCLUDE_DIR AND SQLITE_LIBRARIES )
+
+# use pkg-config to get the directories and then use these values
+# in the FIND_PATH() and FIND_LIBRARY() calls
+if( NOT WIN32 )
+  find_package(PkgConfig)
+
+  pkg_check_modules(PC_SQLITE sqlite3)
+
+  set(SQLITE_DEFINITIONS ${PC_SQLITE_CFLAGS_OTHER})
+endif( NOT WIN32 )
+
+FIND_PATH(SQLITE_INCLUDE_DIR NAMES sqlite3.h
+  PATHS
+  ${PC_SQLITE_INCLUDEDIR}
+  ${PC_SQLITE_INCLUDE_DIRS}
+)
+
+FIND_LIBRARY(SQLITE_LIBRARIES NAMES sqlite3
+  PATHS
+  ${PC_SQLITE_LIBDIR}
+  ${PC_SQLITE_LIBRARY_DIRS}
+)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Sqlite DEFAULT_MSG SQLITE_INCLUDE_DIR SQLITE_LIBRARIES )
+
+# show the SQLITE_INCLUDE_DIR and SQLITE_LIBRARIES variables only in the advanced view
+MARK_AS_ADVANCED(SQLITE_INCLUDE_DIR SQLITE_LIBRARIES )
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,26 +1,22 @@
 # Builds the sqlite wrapper library
 
-set(SQLITE_SOURCE_FILES
-    database.hpp
+set(XXSQLITE_SOURCE_FILES
     database.cpp
-    error.hpp
     error.cpp
-    field.hpp
     field.cpp
-    result.hpp
     result.cpp
-    row.hpp
     row.cpp
-    statement.hpp
     statement.cpp
 )
 
-add_library(sqlite STATIC
-    ${SQLITE_SOURCE_FILES}
+add_library(++sqlite STATIC
+    ${XXSQLITE_SOURCE_FILES}
 )
 
-target_link_libraries(sqlite
-    sqlite3
+include_directories(${SQLITE_INCLUDE_DIRS})
+
+target_link_libraries(++sqlite
+    ${SQLITE_LIBRARIES}
 )
 
 if(BUILD_UNIT_TESTS)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,11 +1,14 @@
-add_executable(test_database
-    test_database.cpp
-)
-target_link_libraries(test_database
-    sqlite
+set(TEST_LIBRARIES
+    ++sqlite
     gtest
     gtest_main
 )
+
+
+add_executable(test_database
+    test_database.cpp
+)
+target_link_libraries(test_database ${TEST_LIBRARIES})
 add_test(test_database
     test_database
 )
@@ -13,11 +16,7 @@ add_test(test_database
 add_executable(test_statement
     test_statement.cpp
 )
-target_link_libraries(test_statement
-    sqlite
-    gtest
-    gtest_main
-)
+target_link_libraries(test_statement ${TEST_LIBRARIES})
 add_test(test_statement
     test_statement
 )
@@ -25,11 +24,7 @@ add_test(test_statement
 add_executable(test_result
     test_result.cpp
 )
-target_link_libraries(test_result
-    sqlite
-    gtest
-    gtest_main
-)
+target_link_libraries(test_result ${TEST_LIBRARIES})
 add_test(test_result
     test_result
 )
@@ -37,11 +32,7 @@ add_test(test_result
 add_executable(test_row
     test_row.cpp
 )
-target_link_libraries(test_row
-    sqlite
-    gtest
-    gtest_main
-)
+target_link_libraries(test_row ${TEST_LIBRARIES})
 add_test(test_row
     test_row
 )
@@ -49,11 +40,7 @@ add_test(test_row
 add_executable(test_field
     test_field.cpp
 )
-target_link_libraries(test_field
-    sqlite
-    gtest
-    gtest_main
-)
+target_link_libraries(test_field ${TEST_LIBRARIES})
 add_test(test_field
     test_field
 )


### PR DESCRIPTION
0) added module Findsqlite (if no sqlite found, cmake will stop with error)
1) renamed library from sqlite to ++sqlite and cmake vars from SQLITE... to XXSQLITE
2) added cmake vars XXSQLITE_INCLUDE_DIRS and XXSQLITE_LIBRARIES for easy integration as git submodule
3) removed header files from XXSQLITE_SOURCE_FILES
